### PR TITLE
Add link to package GoDoc in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # gconf
+
+[![GoDoc](https://godoc.org/github.com/thalmic/gconf?status.svg)](https://godoc.org/github.com/thalmic/gconf)
+
 A simple hierarchical configuration reader, heavily inspired by [nconf](https://github.com/indexzero/nconf).
 
 ## Installation


### PR DESCRIPTION
Since this package is open source, its documentation is automatically rendered and hosted on [godoc.org](https://godoc.org/github.com/thalmic/gconf). It's common for go packages to provide a link to their documentation at the top of the README to help new users.

I feel the godoc for this package could benefit from some enhancement (adding examples, etc.), but the first step toward that goal involves increasing visibility.